### PR TITLE
fix: 修复皎皎角手机号登录

### DIFF
--- a/externals/dna-api/src/index.ts
+++ b/externals/dna-api/src/index.ts
@@ -353,7 +353,7 @@ export class DNAAPI extends DNABaseAPI {
     }
 
     async login(mobile: string, code: string) {
-        return await this.user.login(mobile, code)
+        return await this.h5.login(mobile, code)
     }
 
     async getSmsCode(mobile: string, vJson: string) {

--- a/externals/dna-api/src/modules/h5.ts
+++ b/externals/dna-api/src/modules/h5.ts
@@ -1,4 +1,6 @@
+import type { DNAUserDataBean } from "../type-generated"
 import { DNASubModule } from "./base"
+import { DNA_GAME_ID } from "./types"
 
 export interface DNAMapMatterCategorizeOption {
     icon: string
@@ -103,6 +105,20 @@ export interface DNAEmoji {
 }
 
 export class H5API extends DNASubModule {
+    /**
+     * 使用 H5 协议通过手机号和短信验证码登录。
+     * @param mobile 手机号
+     * @param code 短信验证码
+     * @returns 登录响应
+     */
+    async login(mobile: string, code: string) {
+        const res = await this._dna_request_h5<DNAUserDataBean>("user/sdkLogin", { mobile, code, gameList: DNA_GAME_ID }, { sign: true })
+        if (res.is_success && typeof res.data?.token === "string") {
+            this.token = res.data.token
+        }
+        return res
+    }
+
     /**
      * 发送 H5 版短信验证码。
      * @param mobile 手机号

--- a/src/api/dna-login.test.ts
+++ b/src/api/dna-login.test.ts
@@ -1,0 +1,29 @@
+import { DNA_GAME_ID, DNAAPI, TimeBasicResponse } from "dna-api"
+import { describe, expect, it, vi } from "vitest"
+
+describe("DNA 手机号登录", () => {
+    it("使用与验证码一致的 H5 协议登录", async () => {
+        const api = new DNAAPI({ dev_code: "test-device-code" })
+        const response = new TimeBasicResponse({
+            code: 200,
+            data: {
+                token: "test-token",
+            },
+        })
+        const request = vi.spyOn(api, "_dna_request_h5").mockResolvedValue(response)
+
+        const result = await api.login("13800138000", "123456")
+
+        expect(request).toHaveBeenCalledWith(
+            "user/sdkLogin",
+            {
+                mobile: "13800138000",
+                code: "123456",
+                gameList: DNA_GAME_ID,
+            },
+            { sign: true }
+        )
+        expect(result).toBe(response)
+        expect(api.token).toBe("test-token")
+    })
+})


### PR DESCRIPTION
## 问题

国服皎皎角可以正常接收短信验证码，但提交登录时返回“错误手机号”。

Closes #26

## 修复

- 手机号登录改用与验证码接口一致的 H5 请求协议
- 登录载荷与官网保持一致，仅发送 `mobile`、`code` 和 `gameList`
- 登录成功后保存服务端返回的 token
- 增加回归测试，防止登录重新走 App/Android 协议

## 验证

- 使用真实手机号、短信验证码和官网 `s_uuid` 登录成功
- `pnpm test`：42 个测试文件、440 项测试全部通过
- `dna-api` TypeScript 类型检查通过

说明：仓库全量 `pnpm lint` 仍会被现有的、与本次改动无关的 TypeScript 错误阻断。